### PR TITLE
chore(deps): configure Spotless, SpotBugs and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '23'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Grant Gradle execute permission
@@ -22,6 +22,9 @@ jobs:
 
       - name: Validate formatting (spotlessCheck)
         run: ./gradlew spotlessCheck
+
+      - name: Run SpotBugs analysis
+        run: ./gradlew spotbugsMain spotbugsTest
 
       - name: Run unit tests
         run: ./gradlew test
@@ -32,3 +35,10 @@ jobs:
         with:
           name: test-reports
           path: '**/build/reports/tests/test'
+
+      - name: Generate SpotBugs reports summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: spotbugs-reports
+          path: '**/build/reports/spotbugs/**/*.html'

--- a/build.gradle
+++ b/build.gradle
@@ -8,12 +8,6 @@ plugins {
     id 'com.github.spotbugs' version '6.1.13'
 }
 
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
-    }
-}
-
 ext {
     spotbugsVersion = '4.9.3'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,69 @@
+import com.github.spotbugs.snom.Confidence
+import com.github.spotbugs.snom.Effort
+import com.github.spotbugs.snom.SpotBugsTask
+
 plugins {
+    id 'java'
     id 'com.diffplug.spotless' version '6.25.0'
+    id 'com.github.spotbugs' version '6.1.13'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+ext {
+    spotbugsVersion = '4.9.3'
 }
 
 subprojects {
     apply plugin: 'java'
     apply plugin: 'com.diffplug.spotless'
+    apply plugin: 'com.github.spotbugs'
+
+    configurations {
+        compileOnly
+        spotbugsPlugins
+    }
+
+    dependencies {
+        compileOnly "com.github.spotbugs:spotbugs-annotations:$spotbugsVersion"
+        spotbugs "com.github.spotbugs:spotbugs:$spotbugsVersion"
+        spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.13.0'
+    }
 
     repositories {
         mavenCentral()
+        gradlePluginPortal()
+    }
+
+    spotbugs {
+        toolVersion = spotbugsVersion
+        ignoreFailures = false
+        showStackTraces = true
+        showProgress = true
+        effort = Effort.DEFAULT
+        reportLevel = Confidence.valueOf('DEFAULT')
+        reportsDir = layout.buildDirectory.dir("spotbugs").get().asFile
+        maxHeapSize = '1g'
+    }
+
+    def mainHtmlReport = layout.buildDirectory.file("reports/spotbugs/main/spotbugs.html")
+    def testHtmlReport = layout.buildDirectory.file("reports/spotbugs/test/spotbugs.html")
+
+    tasks.withType(SpotBugsTask).configureEach {
+        reports {
+            html.required.set(true)
+            html.stylesheet = 'fancy-hist.xsl'
+        }
+
+        if (name == "spotbugsMain") {
+            reports.html.outputLocation.set(mainHtmlReport)
+        } else if (name == "spotbugsTest") {
+            reports.html.outputLocation.set(testHtmlReport)
+        }
     }
 
     spotless {
@@ -15,5 +71,15 @@ subprojects {
             googleJavaFormat('1.17.0').aosp()
             target 'src/**/*.java'
         }
+    }
+
+    tasks.named('check') {
+        dependsOn tasks.named('spotbugsMain')
+        dependsOn tasks.named('spotbugsTest')
+        dependsOn tasks.named('spotlessCheck')
+    }
+
+    tasks.named('build') {
+        dependsOn 'spotlessApply'
     }
 }


### PR DESCRIPTION
What’s included:

- Přidání Spotless pluginu pro formátování Java kódu (Google Java Format – AOSP styl)
- Integrace SpotBugs a FindSecBugs pluginů pro statickou analýzu kódu
- Vytvoření HTML reportů pro spotbugsMain a spotbugsTest

CI workflow (ci.yml) pro:
- Kontrolu formátování (spotlessCheck)
- Analýzu pomocí SpotBugs
- Spuštění testů
- Nahrání reportů jako artefakty

🧪 Testováno:
- Lokálně spuštěny: ./gradlew check, ./gradlew build, ./gradlew test
- CI by mělo projít na JDK 21 (jak je definováno v .github/workflows/ci.yml)

📌 Další kroky:
- V budoucnu lze přidat include/exclude filtry pro SpotBugs
- Možno přidat test coverage report nebo CI badge

