### PR TITLE
feat(reportgen): add ReportGen class with tests

### DIFF
--- a/core/src/main/java/utilcalc/core/reportGen/ReportGen.java
+++ b/core/src/main/java/utilcalc/core/reportGen/ReportGen.java
@@ -1,0 +1,24 @@
+package utilcalc.core.reportGen;
+
+import java.time.LocalDate;
+import java.util.List;
+import utilcalc.core.model.input.ReportInputs;
+import utilcalc.core.model.output.Report;
+
+public final class ReportGen {
+
+    private ReportGen() {}
+
+    public static Report generateReport(ReportInputs reportInputs) {
+        LocalDate startDate = reportInputs.startDate();
+        LocalDate endDate = reportInputs.endDate();
+        List<String> tenant = reportInputs.tenant();
+        List<String> owner = reportInputs.owner();
+        String reportPlace = reportInputs.reportPlace();
+        LocalDate reportDate = reportInputs.reportDate();
+        List<String> sources = reportInputs.sources();
+
+        return new Report(
+                startDate, endDate, tenant, owner, reportPlace, reportDate, sources, List.of());
+    }
+}

--- a/core/src/test/java/utilcalc/core/reportGen/ReportGenTest.java
+++ b/core/src/test/java/utilcalc/core/reportGen/ReportGenTest.java
@@ -1,0 +1,36 @@
+package utilcalc.core.reportGen;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static utilcalc.core.reportGen.ReportGen.generateReport;
+
+import org.junit.jupiter.api.Test;
+import utilcalc.core.model.input.ReportInputs;
+import utilcalc.core.model.output.Report;
+
+public class ReportGenTest {
+
+    @Test
+    void valid_ReportInput_should_return_valid_report_class() {
+        ReportInputs reportInputs = ReportInputFactory.validReportInput();
+
+        Report report = generateReport(reportInputs);
+
+        assertThat(report.startDate()).isEqualTo(reportInputs.startDate());
+        assertThat(report.endDate()).isEqualTo(reportInputs.endDate());
+        assertThat(report.tenant()).isEqualTo(reportInputs.tenant());
+        assertThat(report.owner()).isEqualTo(reportInputs.owner());
+        assertThat(report.reportPlace()).isEqualTo(reportInputs.reportPlace());
+        assertThat(report.reportDate()).isEqualTo(reportInputs.reportDate());
+        assertThat(report.sources()).isEqualTo(reportInputs.sources());
+        assertThat(report.sections()).isEmpty();
+    }
+
+    @Test
+    void empty_sources_should_be_empty_in_report_class() {
+        ReportInputs reportInputs = ReportInputFactory.emptySourceReportInput();
+
+        Report report = generateReport(reportInputs);
+
+        assertThat(report.sources()).isEmpty();
+    }
+}

--- a/core/src/test/java/utilcalc/core/reportGen/ReportInputFactory.java
+++ b/core/src/test/java/utilcalc/core/reportGen/ReportInputFactory.java
@@ -1,0 +1,38 @@
+package utilcalc.core.reportGen;
+
+import java.time.LocalDate;
+import java.util.List;
+import utilcalc.core.model.input.ReportInputs;
+import utilcalc.core.model.input.SectionInputs;
+
+final class ReportInputFactory {
+
+    private static final LocalDate START_DATE = LocalDate.of(2024, 1, 1);
+    private static final LocalDate END_DATE = LocalDate.of(2024, 12, 31);
+    private static final List<String> TENANT = List.of("Jméno nájemníka", "Adresa nemovitosti");
+    private static final List<String> OWNER = List.of("Jméno majitele", "majitel@example.com");
+    private static final String REPORT_PLACE = "V Praze";
+    private static final LocalDate REPORT_DATE = LocalDate.of(2025, 2, 15);
+    private static final List<String> SOURCES = List.of("Vyúčtování SVJ");
+    private static final List<String> EMPTY_SOURCES = List.of();
+    private static final List<SectionInputs> SECTIONS = List.of();
+
+    private ReportInputFactory() {}
+
+    public static ReportInputs validReportInput() {
+        return new ReportInputs(
+                START_DATE, END_DATE, TENANT, OWNER, REPORT_PLACE, REPORT_DATE, SOURCES, SECTIONS);
+    }
+
+    public static ReportInputs emptySourceReportInput() {
+        return new ReportInputs(
+                START_DATE,
+                END_DATE,
+                TENANT,
+                OWNER,
+                REPORT_PLACE,
+                REPORT_DATE,
+                EMPTY_SOURCES,
+                SECTIONS);
+    }
+}


### PR DESCRIPTION
Tento pull request přidává třídu ReportGen a její testy.

- Třída slouží ke generování Report ze vstupního ReportInputs.
- ReportGen v této fázi převádí do Report pouze atributy, které se nemění.

Později bude přidáno generování jednotlivých sekcí s výpočty.